### PR TITLE
fcf2cube: centrosymmetric spacegroups need debugging

### DIFF
--- a/fcf2cube/Cubefile.cpp
+++ b/fcf2cube/Cubefile.cpp
@@ -31,7 +31,7 @@
  * @param header
  * @param verbosity
  */
-Cubefile::Cubefile(const ResFile& resfile, const MapValues& mapvals, float margin, short verbosity) :
+Cubefile::Cubefile(const ResFile& resfile, const MapValues& mapvals, double margin, short verbosity) :
 resfile_(resfile),
 mapvals_(mapvals),
 margin_(margin),

--- a/fcf2cube/Cubefile.h
+++ b/fcf2cube/Cubefile.h
@@ -38,14 +38,14 @@ private:
     //! lower left corner of box is origin of map
     Vec3 llc_, urc_;
     Vec3 ex_, ey_, ez_;
-    float margin_;
+    double margin_;
     short verbosity_;
     
     void makemap();
     
 public:
     Cubefile() = delete;
-    Cubefile(const ResFile& resfile, const MapValues& mapvals, float margin, short verbosity);
+    Cubefile(const ResFile& resfile, const MapValues& mapvals, double margin, short verbosity);
     ~Cubefile() = default;
     
     //! mark too close atoms to be skipped

--- a/fcf2cube/FCFInfo.h
+++ b/fcf2cube/FCFInfo.h
@@ -21,8 +21,8 @@
 
 
 class FCFInfo {
-    float a_,b_,c_;
-    float alpha_, beta_, gamma_;
+    double a_,b_,c_;
+    double alpha_, beta_, gamma_;
     double dhighres_;
     double F000_;
     
@@ -31,27 +31,26 @@ class FCFInfo {
     int verbosity_;
     
     std::vector<Int3x3> symops_;
-    bool check_inversion() const;
 
 public:
-    FCFInfo(float a, float b, float c, float alpha_, float beta_, float gamma_,
-            float dhighres, float F000, const std::vector<Int3x3> symops, int verbosity);
+    FCFInfo(double a, double b, double c, double alpha_, double beta_, double gamma_,
+            double dhighres, double F000, const std::vector<Int3x3> symops, int verbosity);
     FCFInfo() = default;
     ~FCFInfo() = default;
     
-    float a() const { return a_; }
-    float b() const { return b_; }
-    float c() const { return c_; }
-    float alpha() const { return alpha_; }
-    float beta() const { return beta_; }
-    float gamma() const { return gamma_; }
-    float dhighres() const { return dhighres_; }
+    double a() const { return a_; }
+    double b() const { return b_; }
+    double c() const { return c_; }
+    double alpha() const { return alpha_; }
+    double beta() const { return beta_; }
+    double gamma() const { return gamma_; }
+    double dhighres() const { return dhighres_; }
     
-    float fftscale() const;
+    double fftscale() const;
     
     std::vector<Int3x3> symops() const { return symops_; }
     // eliminate lattice and inversion operators
-    std::vector<Int3x3> symops_no_inv() const;
+    std::vector<Int3x3> symops_no_inv();
     int nsymops() const { return symops_.size();}
     
     bool centrosymmetric() const { return centrosymmetric_; }

--- a/fcf2cube/FCFfile.cpp
+++ b/fcf2cube/FCFfile.cpp
@@ -64,13 +64,13 @@ void FCFfile::read_fcfheader(std::ifstream& inp, const double& f000) {
 
     int listcode (-1);
     double Fcalcmax;
-    float F000;
+    double F000;
 
     /*
      *  some initialisations
      */
-    float a, b, c, alpha, beta, gamma;
-    float dhighres = -1.0;
+    double a, b, c, alpha, beta, gamma;
+    double dhighres = -1.0;
     std::vector<Int3x3> symops;
     
     while (! inp.fail() ) {
@@ -174,7 +174,7 @@ void FCFfile::read_fcfdata(std::ifstream& inp) {
     double Imeas; //! actually F^2
     double sigImeas;
     double Fcalc;
-    float  phicalc;
+    double  phicalc;
 
     // finally read the data
     if (verbosity_ > 1) {

--- a/fcf2cube/MapValues.cpp
+++ b/fcf2cube/MapValues.cpp
@@ -36,7 +36,7 @@ int MapValues::idx(int j, int k, int l) const {
  * @return 
  */
 double MapValues::in_unitcell(const double& x) const {
-    float X = std::fmod(x, 1.0);
+    double X = std::fmod(x, 1.0);
     if (X < 0) X += 1.0;
     return X;
 }

--- a/fcf2cube/Parser.h
+++ b/fcf2cube/Parser.h
@@ -28,9 +28,9 @@ private:
     short maptype_;
     bool read_qs_;
     //! how much extra of molecule to cover
-    float margin_;
-    float weight_weaks_;
-    float hklgridres_;
+    double margin_;
+    double weight_weaks_;
+    double hklgridres_;
     unsigned short verbosity_;
 
     template <typename T> bool getoption(const std::string& option,
@@ -73,15 +73,15 @@ public:
         return read_qs_;
     }
 
-    float margin() const {
+    double margin() const {
         return margin_;
     }
 
-    float weight() const {
+    double weight() const {
         return weight_weaks_;
     }
 
-    float hklgridres() const {
+    double hklgridres() const {
         return hklgridres_;
     }
 

--- a/fcf2cube/ResFile.h
+++ b/fcf2cube/ResFile.h
@@ -34,8 +34,8 @@ private:
     struct XAtom {
         std::string name_ = "";
         unsigned short sfac_idx_ = 0;
-        float x_, y_, z_;
-        float occupancy_;
+        double x_, y_, z_;
+        double occupancy_;
         bool skip_ = false;
     } xatom;
     struct SfacZ {
@@ -53,10 +53,10 @@ private:
     std::vector<SfacZ> sfacsZ_;
     std::vector<XAtom> xatoms_;
     
-    float lambda_;
-    float a_, b_, c_;
+    double lambda_;
+    double a_, b_, c_;
     // angles are kept as angles (degree) here
-    float alpha_, beta_, gamma_;
+    double alpha_, beta_, gamma_;
     
     //! unit cell vectors
     Vec3 A_, B_, C_;

--- a/fcf2cube/Utils.cpp
+++ b/fcf2cube/Utils.cpp
@@ -130,12 +130,12 @@ std::string Utils::error(const unsigned short& verbosity) {
  * @return 
  */
 std::tuple<Vec3, Vec3, Vec3> Utils::unit_cell_vectors(double a, double b, double c, double alpha, double beta, double gamma) {
-    const float salpha = std::sin(alpha * M_PI / 180.0);
-    const float calpha = std::cos(alpha * M_PI / 180.0);
-    const float sbeta  = std::sin(beta  * M_PI / 180.0);
-    const float cbeta  = std::cos(beta  * M_PI / 180.0);
-    const float sgamma = std::sin(gamma * M_PI / 180.0);
-    const float cgamma = std::cos(gamma * M_PI / 180.0);
+    const double salpha = std::sin(alpha * M_PI / 180.0);
+    const double calpha = std::cos(alpha * M_PI / 180.0);
+    const double sbeta  = std::sin(beta  * M_PI / 180.0);
+    const double cbeta  = std::cos(beta  * M_PI / 180.0);
+    const double sgamma = std::sin(gamma * M_PI / 180.0);
+    const double cgamma = std::cos(gamma * M_PI / 180.0);
     Vec3 A = Vec3(a, 0.0, 0.0);
     Vec3 B = Vec3(b*cgamma, b*sgamma, 0);
         double cx = c * cbeta;

--- a/fcf2cube/main.cpp
+++ b/fcf2cube/main.cpp
@@ -54,6 +54,12 @@ int main(int argc, char** argv) {
         // compute fft
         sxfft myfft(fcfdata, fcfinfo, parser.maptype(), parser.verbosity());
         myfft.fft(parser.weight(), parser.hklgridres());
+	if (parser.verbosity() > 1) {
+		std::string outmap = "my_ascii.map";
+		std::cout << Utils::prompt(2) << "Writing fft data to my " <<
+		outmap << '\n';
+		myfft.asciimap(outmap);
+	}
         
         // create the map for the Cubefile surrounding molecule
         MapValues mapvals(myfft.map(), myfft.gridn1(), myfft.gridn2(), myfft.gridn3(), parser.verbosity());


### PR DESCRIPTION
fcf2cube produces the same (ascii) output as sxfft.f, but for centrosymmetric spacegroups, figures do not match. These are the bug fixes in tracing this discrepancy.